### PR TITLE
Do not install 3rd party header except Eigen and GL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,6 @@ endif ()
 
 if (BUILD_JPEG)
     add_subdirectory(libjpeg)
-    INSTALL_HEADERS(libjpeg)
 endif ()
 
 # JSONCPP
@@ -138,7 +137,6 @@ else ()
 
     if (BUILD_JSONCPP)
         add_subdirectory(jsoncpp)
-        INSTALL_HEADERS(jsoncpp)
     endif ()
 endif ()
 
@@ -159,8 +157,6 @@ endif ()
 if (BUILD_PNG)
     add_subdirectory(zlib)
     add_subdirectory(libpng)
-    INSTALL_HEADERS(zlib)
-    INSTALL_HEADERS(libpng)
     list(APPEND PNG_LIBRARIES zlib)
 endif ()
 
@@ -186,7 +182,6 @@ if (BUILD_LIBREALSENSE)
     message(STATUS "Building LIBREALSENSE from source")
     add_subdirectory(librealsense)
     Directories("${CMAKE_CURRENT_SOURCE_DIR}/librealsense" librealsense_INCLUDE_DIRS)
-    INSTALL_HEADERS(librealsense)
 endif ()
 
 # tinyfiledialogs
@@ -195,7 +190,6 @@ if (BUILD_TINYFILEDIALOGS)
     add_subdirectory(tinyfiledialogs)
     set(tinyfiledialogs_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/tinyfiledialogs")
     set(tinyfiledialogs_LIBRARIES tinyfiledialogs)
-    INSTALL_HEADERS(tinyfiledialogs)
 else ()
     message(SEND_ERROR "TINYFILEDIALOGS dependency not met.")
 endif ()
@@ -218,6 +212,15 @@ list(APPEND 3RDPARTY_INCLUDE_DIRS
      ${PNG_INCLUDE_DIRS}
      ${rply_INCLUDE_DIRS}
      ${tinyfiledialogs_INCLUDE_DIRS})
+
+# set 3RDPARTY_INCLUDE_DIRS_AT_INSTALL
+# Open3D's header only dependes on Eigen and GL headers
+# The future plan is to minimize such dependencies
+list(APPEND 3RDPARTY_INCLUDE_DIRS_AT_INSTALL
+     ${EIGEN3_INCLUDE_DIRS}
+     ${GLEW_INCLUDE_DIRS}
+     ${GLFW_INCLUDE_DIRS}
+)
 
 # set 3RDPARTY_LIBRARY_DIRS
 list(APPEND 3RDPARTY_LIBRARY_DIRS
@@ -260,6 +263,7 @@ if (NOT BUILD_TINYFILEDIALOGS)
 endif ()
 
 set(3RDPARTY_INCLUDE_DIRS ${3RDPARTY_INCLUDE_DIRS} PARENT_SCOPE)
+set(3RDPARTY_INCLUDE_DIRS_AT_INSTALL ${3RDPARTY_INCLUDE_DIRS_AT_INSTALL} PARENT_SCOPE)
 set(3RDPARTY_LIBRARY_DIRS ${3RDPARTY_LIBRARY_DIRS} PARENT_SCOPE)
 set(3RDPARTY_LIBRARIES    ${3RDPARTY_LIBRARIES}    PARENT_SCOPE)
 set(PRE_BUILT_3RDPARTY_LIBRARIES ${PRE_BUILT_3RDPARTY_LIBRARIES} PARENT_SCOPE)


### PR DESCRIPTION
### Before
```
# Open3D_INCLUDE_DIRS when installed
${PACKAGE_PREFIX_DIR}/include/Open3D
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/Eigen
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/flann
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/flann/algorithms
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/flann/nn
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/flann/util
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/glew/include
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/GLFW/include;/usr/include
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/libjpeg
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/jsoncpp/include
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/liblzf
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/libpng
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/rply
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/rply/etc
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/rply/manual
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/tinyfiledialogs
```

### After
```
# Open3D_INCLUDE_DIRS when installed
${PACKAGE_PREFIX_DIR}/include/Open3D
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/Eigen
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/glew/include
${PACKAGE_PREFIX_DIR}/include/Open3D/3rdparty/GLFW/include;/usr/include
```
Pre-installed libs are also supported. E.g. if eigen is aready installed in system library, the system's include directory will be used such as:
```
/usr/include/eigen3
```

### Future works
In theory, installing Open3D shall not install any 3rd-party headers. However, Open3D headers currently depend on Eigen and OpenGL headers. Therefore we made an exception to install Eigen and OpenGL headers along with Open3D. In the future, we could look into removing header dependencies of 3rd party libraries.